### PR TITLE
packages/demo: enforce local workspace resolution of sveltefirets

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^2.7.2",
     "svelte-pieces": "^1.0.22",
     "svelte-preprocess": "^4.10.1",
-    "sveltefirets": "^0.0.26",
+    "sveltefirets": "workspace:^0.0.27",
     "tslib": "^2.3.1",
     "typescript": "~4.7.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
       svelte-check: ^2.7.2
       svelte-pieces: ^1.0.22
       svelte-preprocess: ^4.10.1
-      sveltefirets: ^0.0.26
+      sveltefirets: workspace:^0.0.27
       tslib: ^2.3.1
       typescript: ~4.7.3
     devDependencies:
@@ -1106,6 +1106,11 @@ packages:
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -2108,6 +2113,8 @@ packages:
       debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.2.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /no-case/3.0.4:
@@ -2148,6 +2155,8 @@ packages:
       rimraf: 2.7.1
       semver: 5.7.1
       tar: 4.4.19
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /nopt/4.0.3:


### PR DESCRIPTION
sveltefirets was updated to 0.0.27 in https://github.com/jacob-8/sveltefirets/commit/1bd0aef1d68b75888e3f6cc026bfb1c5eb3248dd but we forgot to update it in demo.

I was trying to run demo with modified version of sveltefirets (to test SAMLAuthProvider which is currently missing in demo).
I found that because of version mismatch pnpm was fetching sveltefirets from npm (skipping local module resolution that was working before).

Using [Workspace protocol](https://pnpm.io/workspaces#workspace-protocol-workspace) I have enforced local resolution of sveltefirets in demo to prevent this issue from happening in future.