### PR TITLE
Fixing typo in examples

### DIFF
--- a/packages/demo/src/routes/1-auth/1-user-store/+page.svx
+++ b/packages/demo/src/routes/1-auth/1-user-store/+page.svx
@@ -68,7 +68,7 @@ export const load: LayoutLoad = async ({ data }) => {
   import { page } from '$app/stores';
   import { authState } from 'sveltefirets';
   import { user as userStore } from '$lib/user';
-  $: user = $userStore || (authState === undefined && $page.data?.user) || null; 
+  $: user = $userStore || ($authState === undefined && $page.data?.user) || null; 
   // only use page data set from the cookie before authState has been inited so that when a user logs out, the user value here doesn't fall back to the page data  value initially set by the cookie. Even though the cookie is cleared on logout, the page data is not updated.
 </script>
 {user?.email}


### PR DESCRIPTION
In the example for the user store, the code was checking if `authState === undefined`, as `authState` is a getter, it will not be undefined.

To check if the value of the getter is undefined, I changed it to `$authState === undefined` and it now works.

